### PR TITLE
resolve github complaint by bumping django version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url
-Django==2.2.3
+Django==2.2.4
 gunicorn
 psycopg2
 whitenoise


### PR DESCRIPTION
you will have to reinstall django, ex.:
```
$ pip3 install -r requirements.txt
```

testing:
bopped around the site a bit, nothing (more) seemed broken