### PR TITLE
fix prod logging by disabling django heroku override

### DIFF
--- a/citycouncil/prod_settings.py
+++ b/citycouncil/prod_settings.py
@@ -50,4 +50,4 @@ CSRF_COOKIE_SECURE = True
 #     'whitenoise.middleware.WhiteNoiseMiddleware',
 # ]
 
-django_heroku.settings(locals())
+django_heroku.settings(locals(), logging=False)


### PR DESCRIPTION
Django by default filters out all console logs via require_debug_true filter in prod. We added an override that should have changed that behavior, but django_heroku completely overrides the LOGGING dictionary which ends up not overwriting the console handler.

I'm not sure exactly how the logging overrides work, but I've verified I think this works with

```
# before
[nav] In [2]: import logging
         ...: console = logging.getLogger("django").handlers[0]
         ...: console.filters[0]
Out[2]: <django.utils.log.RequireDebugTrue at 0x7f2098270280>
```
... copy LOGGING to top of settings.py, add logging=False to django_heroku call in settings.py ...
```
[nav] In [1]: import logging
         ...: console = logging.getLogger("django").handlers[0]
         ...: console.filters[0]
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-1-068d0b4c6515> in <module>
      1 import logging
      2 console = logging.getLogger("django").handlers[0]
----> 3 console.filters[0]

IndexError: list index out of range
```