### PR TITLE
redirect from old urls to new pages to recapture some of our pagerank

### DIFF
--- a/django_app/citycouncil/settings.py
+++ b/django_app/citycouncil/settings.py
@@ -16,6 +16,10 @@ CSRF_TRUSTED_ORIGINS = [
     "https://www.cambridge-wh2u.onrender.com",
     "https://cambridge.vote",
     "https://www.cambridge.vote",
+
+    # old urls, to be removed after 2025
+    "https://cambridgecouncilcandidates.com",
+    "https://www.cambridgecouncilcandidates.com",
 ]
 ATOMIC_REQUESTS = True
 

--- a/django_app/citycouncil/urls.py
+++ b/django_app/citycouncil/urls.py
@@ -4,7 +4,7 @@ The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/1.11/topics/http/urls/
 """
 
-from django.urls import re_path, include
+from django.urls import re_path, include, path
 from django.contrib import admin
 from django.views.generic.base import RedirectView
 
@@ -110,4 +110,34 @@ urlpatterns = [
         },
         name="django.contrib.sitemaps.views.sitemap",
     ),
+
+]
+
+urlpatterns += [
+    # Old urls from cambridgecouncilcandidate that appear in google search results
+    # this is a temporary hack to mitigate the page rank loss from changing domains
+    # after ranking pretty well last cycle.
+    path(
+        f"candidates/{old_name}/",
+        RedirectView.as_view(
+            url=f"https://cambridge.vote/2025/council/candidates/{new_name}/",
+            permanent=True,
+        ),
+    )
+
+    for old_name, new_name in [
+        ("ayah-al-zubi", "ayah-al-zubi"),
+        ("ayesha-wilson", "ayesha-wilson"),
+        ("burhan-azeem", "burhan-azeem"),
+        ("catherine-zusy", "cathie-zusy"),
+        ("denise-simmons", "e-denise-simmons"),
+        ("jivan-sobrinho-wheeler", "jivan-sobrinho-wheeler"),
+        ("john-hanratty", "john-hanratty"),
+        ("marc-mcgovern", "marc-mcgovern"),
+        ("patty-nolan", "patty-nolan"),
+        ("paul-toner", "paul-toner"),
+        ("peter-hsu", "peter-hsu"),
+        ("robert-winters", "robert-winters"),
+        ("sumbul-siddiqui", "sumbul-siddiqui"),
+    ]
 ]


### PR DESCRIPTION
cambridgecouncilcandidates ranked well for some candidates in google search results but cambridge.vote is ranking extremely poorly so far. I'm hoping that by adding a permanent redirect https://www.cambridgecouncilcandidates.com/candidates/catherine-zusy/ (3rd result for her name) to https://www.cambridge.vote/2025/council/candidates/cathie-zusy/, we'll be able to capture some of that ranking.

After deploying, we should attempt to re-add the site to render.com under cambridgecouncilcandidates. It'd be a good idea to capture all traffic and rewrite it to cambridge.vote to avoid those two sites fighting with each other although we have canonical urls that use cambridge.vote via the sites framework.

A domain -> domain redirect would likely be a better approach but this will still be useful and would take an old style link /candidates/catherine-zusy/ and get the right new page for it.